### PR TITLE
No need for package_dir in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     keywords = "google gmail",
     url = "https://github.com/charlierguo/gmail",
     packages=['gmail'],
-    package_dir={'gmail': ''},
     long_description=read('README.md'),
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
package_dir is to specify your package source directory. For example if you have package foo which exist in lib directory then you need to specify lib to package_dir. 

That is why build got failed with below error,
running build
running build_py
package init file '**init**.py' not found (or not a regular file)
