### PR TITLE
Fetch full thread (sent and received) for a received message

### DIFF
--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -1,6 +1,7 @@
 import imaplib
 from mailbox import Mailbox
 from exceptions import *
+import re
 
 class Gmail():
     # GMail IMAP defaults
@@ -139,6 +140,16 @@ class Gmail():
             self.use_mailbox(from_mailbox)
         self.imap.uid('COPY', uid, to_mailbox)
 
+    def fetch_multiple_messages(self, messages):
+        fetch_str =  ','.join(messages.items())
+        response, results = self.imap.uid('FETCH', fetch_str, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
+        for index in xrange(len(results) - 1):
+            raw_message = results[index]
+            if re.search(r'UID (\d+)', raw_message[0]):
+                uid = re.search(r'UID (\d+)', raw_message[0]).groups(1)[0]
+                messages[uid].parse(raw_message)
+
+        return messages
 
 
     def labels(self):

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -156,6 +156,9 @@ class Gmail():
     def all_mail(self):
         return self.mailbox("[Gmail]/All Mail")
 
+    def sent_mail(self):
+        return self.mailbox("[Gmail]/Sent Mail")
+
     def important(self):
         return self.mailbox("[Gmail]/Important")
 

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -141,7 +141,7 @@ class Gmail():
         self.imap.uid('COPY', uid, to_mailbox)
 
     def fetch_multiple_messages(self, messages):
-        fetch_str =  ','.join(messages.items())
+        fetch_str =  ','.join(messages.keys())
         response, results = self.imap.uid('FETCH', fetch_str, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
         for index in xrange(len(results) - 1):
             raw_message = results[index]

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -1,6 +1,5 @@
 from message import Message
 from utf import encode as encode_utf7
-import re
 
 class Mailbox():
 
@@ -56,13 +55,10 @@ class Mailbox():
                 emails.append(self.messages[uid])
 
             if prefetch:
-                fetch_str = ','.join(uids)
-                response, results = self.gmail.imap.uid('FETCH', fetch_str, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
-                for index in xrange(len(results) - 1):
-                    raw_message = results[index]
-                    if re.search(r'UID (\d+)', raw_message[0]):
-                        uid = re.search(r'UID (\d+)', raw_message[0]).groups(1)[0]
-                        self.messages[uid].parse(raw_message)
+                messages_dict = {}
+                for email in emails:
+                    messages_dict[email.uid] = email
+                self.messages.update(self.gmail.fetch_multiple_messages(messages_dict))
 
         return emails
 

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -66,5 +66,5 @@ class Mailbox():
     def count(*args):
         return len(self.emails(*args))
 
-    def cached_messages():
+    def cached_messages(self):
         return self.messages


### PR DESCRIPTION
I wanted the ability to fetch a full thread as it appears in the gmail interface (both sent and received), so I added fetch_thread() for a message.  It caches the messages in the appropriate Mailbox.messages as well.  It only works if called on a message that was sent to the user, not on a sent message.  If there's interest I can make it more flexible.  Perhaps a Thread object that wraps all emails?  Maybe that's too much.

On another note, the idea of there being a current_mailbox for a Gmail object caused problems for me - that state can change in unpredictable ways.  It seems to me that any function that involves a mailbox should somehow take an arg for it rather than change something that's hard to follow.  I can make an issue and work on that too if you want.
