### PR TITLE
Improve unicode label support

### DIFF
--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -1,7 +1,9 @@
-import imaplib
-from mailbox import Mailbox
-from exceptions import *
 import re
+import imaplib
+
+from mailbox import Mailbox
+from utf import encode as encode_utf7
+from exceptions import *
 
 class Gmail():
     # GMail IMAP defaults
@@ -62,7 +64,10 @@ class Gmail():
         self.current_mailbox = mailbox
 
     def mailbox(self, mailbox_name):
+        if mailbox_name not in self.mailboxes:
+            mailbox_name = encode_utf7(mailbox_name)
         mailbox = self.mailboxes.get(mailbox_name)
+
         if mailbox and not self.current_mailbox == mailbox_name:
             self.use_mailbox(mailbox_name)
 

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -2,7 +2,7 @@ import re
 import imaplib
 
 from mailbox import Mailbox
-from utf import encode as encode_utf7
+from utf import encode as encode_utf7, decode as decode_utf7
 from exceptions import *
 
 class Gmail():
@@ -158,8 +158,11 @@ class Gmail():
         return messages
 
 
-    def labels(self):
-        return self.mailboxes.keys()
+    def labels(self, require_unicode=False):
+        keys = self.mailboxes.keys()
+        if require_unicode:
+            keys = [decode_utf7(key) for key in keys]
+        return keys
 
     def inbox(self):
         return self.mailbox("INBOX")

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -56,7 +56,6 @@ class Gmail():
 
     def use_mailbox(self, mailbox):
         if mailbox:
-            # TODO: utf-7 encode mailbox name
             self.imap.select(mailbox)
         self.current_mailbox = mailbox
 

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -52,7 +52,9 @@ class Gmail():
         if response == 'OK':
             for mailbox in mailbox_list:
                 mailbox_name = mailbox.split('"/"')[-1].replace('"', '').strip()
-                self.mailboxes[mailbox_name] = Mailbox(self, mailbox_name)
+                mailbox = Mailbox(self)
+                mailbox.external_name = mailbox_name
+                self.mailboxes[mailbox_name] = mailbox
 
     def use_mailbox(self, mailbox):
         if mailbox:

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -1,16 +1,26 @@
 from message import Message
-from utf import encode as encode_utf7
+from utf import encode as encode_utf7, decode as decode_utf7
+
 
 class Mailbox():
 
     def __init__(self, gmail, name="INBOX"):
         self.name = name
-        # TODO: utf-7 encode mailbox name
-        self.external_name = encode_utf7(name)
         self.gmail = gmail
         self.date_format = "%d-%b-%Y"
         self.messages = {}
 
+    @property
+    def external_name(self):
+        if "external_name" not in vars(self):
+            vars(self)["external_name"] = encode_utf7(self.name)
+        return vars(self)["external_name"]
+
+    @external_name.setter
+    def external_name(self, value):
+        if "external_name" in vars(self):
+            del vars(self)["external_name"]
+        self.name = decode_utf7(value)
 
     def mail(self, prefetch=False, **kwargs):
         search = ['ALL']


### PR DESCRIPTION
Currently we could only get UTF-7 encoded label from the public API. This pull request use the implemented `utils.py` to improve support for unicode label.

This modified is compatible with old usage, and added more such as calling like `gmail_account.label(u"中文标签")`. A new optional argument has been added to `Gmail.labels` method, `gmail_account.labels(require_unicode=True)` will decode all UTF-7 string to human-readable label.

Please review, thanks. :smile:
