### PR TITLE
Fix missing variable in threads list

### DIFF
--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -67,6 +67,7 @@ class Mailbox():
 
     # WORK IN PROGRESS. NOT FOR ACTUAL USE
     def threads(self, prefetch=False, **kwargs):
+        emails = []
         response, data = self.gmail.imap.uid('SEARCH', 'ALL')
         if response == 'OK':    
             uids = data[0].split(' ') 


### PR DESCRIPTION
An error was caused in the `threads` function by the the `emails` variable not having been defined as a list before being appended to.  This is just a quick fix - tested and worked for me in Python 2.7

Old behavior:

```
>>> print g.inbox().threads()
NameError: global name 'emails' is not defined
```

New behavior:

```
>>> print g.inbox().threads()
<gmail.message.Message instance at 0x107752170>, <gmai....
```
