### PR TITLE
Encoding and mailbox attrs

### DIFF
--- a/gmail/__init__.py
+++ b/gmail/__init__.py
@@ -14,8 +14,7 @@ __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2013 Charlie Guo'
 
 from .gmail import Gmail
-from .mailbox import Mailbox 
-from .message import Message 
+from .mailbox import Mailbox
+from .message import Message
 from .exceptions import GmailException, ConnectionError, AuthenticationError
 from .utils import login, authenticate
-

--- a/gmail/exceptions.py
+++ b/gmail/exceptions.py
@@ -13,11 +13,14 @@ class GmailException(RuntimeError):
     """There was an ambiguous exception that occurred while handling your
     request."""
 
+
 class ConnectionError(GmailException):
     """A Connection error occurred."""
 
+
 class AuthenticationError(GmailException):
     """Gmail Authentication failed."""
+
 
 class Timeout(GmailException):
     """The request timed out."""

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -54,8 +54,10 @@ class Gmail():
         if response == 'OK':
             for mailbox in mailbox_list:
                 mailbox_name = mailbox.split('"/"')[-1].replace('"', '').strip()
+                mailbox_attrs = mailbox.split('"/"')[0]
                 mailbox = Mailbox(self)
                 mailbox.external_name = mailbox_name
+                mailbox.attrs = mailbox_attrs
                 self.mailboxes[mailbox_name] = mailbox
 
     def use_mailbox(self, mailbox):
@@ -140,7 +142,7 @@ class Gmail():
         box = self.mailbox(mailbox_name)
         return box.mail(**kwargs)
 
-    
+
     def copy(self, uid, to_mailbox, from_mailbox=None):
         if from_mailbox:
             self.use_mailbox(from_mailbox)

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -5,6 +5,7 @@ from mailbox import Mailbox
 from utf import encode as encode_utf7, decode as decode_utf7
 from exceptions import *
 
+
 class Gmail():
     # GMail IMAP defaults
     GMAIL_IMAP_HOST = 'imap.gmail.com'
@@ -26,9 +27,7 @@ class Gmail():
         self.mailboxes = {}
         self.current_mailbox = None
 
-
         # self.connect()
-
 
     def connect(self, raise_errors=True):
         # try:
@@ -47,7 +46,6 @@ class Gmail():
         # self.smtp.ehlo()
 
         return self.imap
-
 
     def fetch_mailboxes(self):
         response, mailbox_list = self.imap.list()
@@ -90,8 +88,6 @@ class Gmail():
             self.imap.delete(mailbox_name)
             del self.mailboxes[mailbox_name]
 
-
-
     def login(self, username, password):
         self.username = username
         self.password = password
@@ -106,7 +102,6 @@ class Gmail():
                 self.fetch_mailboxes()
         except imaplib.IMAP4.error:
             raise AuthenticationError
-
 
         # smtp_login(username, password)
 
@@ -134,7 +129,6 @@ class Gmail():
         self.imap.logout()
         self.logged_in = False
 
-
     def label(self, label_name):
         return self.mailbox(label_name)
 
@@ -142,14 +136,13 @@ class Gmail():
         box = self.mailbox(mailbox_name)
         return box.mail(**kwargs)
 
-
     def copy(self, uid, to_mailbox, from_mailbox=None):
         if from_mailbox:
             self.use_mailbox(from_mailbox)
         self.imap.uid('COPY', uid, to_mailbox)
 
     def fetch_multiple_messages(self, messages):
-        fetch_str =  ','.join(messages.keys())
+        fetch_str = ','.join(messages.keys())
         response, results = self.imap.uid('FETCH', fetch_str, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
         for index in xrange(len(results) - 1):
             raw_message = results[index]
@@ -158,7 +151,6 @@ class Gmail():
                 messages[uid].parse(raw_message)
 
         return messages
-
 
     def labels(self, require_unicode=False):
         keys = self.mailboxes.keys()

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -9,6 +9,7 @@ class Mailbox():
         self.gmail = gmail
         self.date_format = "%d-%b-%Y"
         self.messages = {}
+        self.attrs = ""
 
     @property
     def external_name(self):

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -1,5 +1,7 @@
-from message import Message
+import re
 from utf import encode as encode_utf7, decode as decode_utf7
+
+from message import Message
 
 
 class Mailbox():
@@ -26,21 +28,21 @@ class Mailbox():
     def mail(self, prefetch=False, **kwargs):
         search = ['ALL']
 
-        kwargs.get('read')   and search.append('SEEN')
+        kwargs.get('read') and search.append('SEEN')
         kwargs.get('unread') and search.append('UNSEEN')
 
-        kwargs.get('starred')   and search.append('FLAGGED')
+        kwargs.get('starred') and search.append('FLAGGED')
         kwargs.get('unstarred') and search.append('UNFLAGGED')
 
-        kwargs.get('deleted')   and search.append('DELETED')
+        kwargs.get('deleted') and search.append('DELETED')
         kwargs.get('undeleted') and search.append('UNDELETED')
 
-        kwargs.get('draft')   and search.append('DRAFT')
+        kwargs.get('draft') and search.append('DRAFT')
         kwargs.get('undraft') and search.append('UNDRAFT')
 
         kwargs.get('before') and search.extend(['BEFORE', kwargs.get('before').strftime(self.date_format)])
-        kwargs.get('after')  and search.extend(['SINCE', kwargs.get('after').strftime(self.date_format)])
-        kwargs.get('on')     and search.extend(['ON', kwargs.get('on').strftime(self.date_format)])
+        kwargs.get('after') and search.extend(['SINCE', kwargs.get('after').strftime(self.date_format)])
+        kwargs.get('on') and search.extend(['ON', kwargs.get('on').strftime(self.date_format)])
 
         kwargs.get('header') and search.extend(['HEADER', kwargs.get('header')[0], kwargs.get('header')[1]])
 
@@ -62,7 +64,7 @@ class Mailbox():
         # print search
         response, data = self.gmail.imap.uid('SEARCH', *search)
         if response == 'OK':
-            uids = filter(None, data[0].split(' ')) # filter out empty strings
+            uids = filter(None, data[0].split(' '))  # filter out empty strings
 
             for uid in uids:
                 if not self.messages.get(uid):
@@ -83,7 +85,6 @@ class Mailbox():
         response, data = self.gmail.imap.uid('SEARCH', 'ALL')
         if response == 'OK':
             uids = data[0].split(' ')
-
 
             for uid in uids:
                 if not self.messages.get(uid):

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -55,11 +55,12 @@ class Mailbox():
         kwargs.get('attachment') and search.extend(['HAS', 'attachment'])
 
         kwargs.get('query') and search.extend([kwargs.get('query')])
+        kwargs.get('custom_query') and search.extend(kwargs.get('custom_query'))
 
         emails = []
         # print search
         response, data = self.gmail.imap.uid('SEARCH', *search)
-        if response == 'OK':    
+        if response == 'OK':
             uids = filter(None, data[0].split(' ')) # filter out empty strings
 
             for uid in uids:
@@ -79,8 +80,8 @@ class Mailbox():
     def threads(self, prefetch=False, **kwargs):
         emails = []
         response, data = self.gmail.imap.uid('SEARCH', 'ALL')
-        if response == 'OK':    
-            uids = data[0].split(' ') 
+        if response == 'OK':
+            uids = data[0].split(' ')
 
 
             for uid in uids:

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -4,8 +4,9 @@ import re
 import time
 import os
 
-from email.header import decode_header, make_header
+from email.header import decode_header
 from imaplib import ParseFlags
+
 
 class Message():
     def __init__(self, mailbox, uid):
@@ -42,12 +43,14 @@ class Message():
     def read(self):
         flag = '\\Seen'
         self.gmail.imap.uid('STORE', self.uid, '+FLAGS', flag)
-        if flag not in self.flags: self.flags.append(flag)
+        if flag not in self.flags:
+            self.flags.append(flag)
 
     def unread(self):
         flag = '\\Seen'
         self.gmail.imap.uid('STORE', self.uid, '-FLAGS', flag)
-        if flag in self.flags: self.flags.remove(flag)
+        if flag in self.flags:
+            self.flags.remove(flag)
 
     def is_starred(self):
         return ('\\Flagged' in self.flags)
@@ -55,12 +58,14 @@ class Message():
     def star(self):
         flag = '\\Flagged'
         self.gmail.imap.uid('STORE', self.uid, '+FLAGS', flag)
-        if flag not in self.flags: self.flags.append(flag)
+        if flag not in self.flags:
+            self.flags.append(flag)
 
     def unstar(self):
         flag = '\\Flagged'
         self.gmail.imap.uid('STORE', self.uid, '-FLAGS', flag)
-        if flag in self.flags: self.flags.remove(flag)
+        if flag in self.flags:
+            self.flags.remove(flag)
 
     def is_draft(self):
         return ('\\Draft' in self.flags)
@@ -72,12 +77,14 @@ class Message():
     def add_label(self, label):
         full_label = '%s' % label
         self.gmail.imap.uid('STORE', self.uid, '+X-GM-LABELS', full_label)
-        if full_label not in self.labels: self.labels.append(full_label)
+        if full_label not in self.labels:
+            self.labels.append(full_label)
 
     def remove_label(self, label):
         full_label = '%s' % label
         self.gmail.imap.uid('STORE', self.uid, '-X-GM-LABELS', full_label)
-        if full_label in self.labels: self.labels.remove(full_label)
+        if full_label in self.labels:
+            self.labels.remove(full_label)
 
     def is_deleted(self):
         return ('\\Deleted' in self.flags)
@@ -85,7 +92,8 @@ class Message():
     def delete(self):
         flag = '\\Deleted'
         self.gmail.imap.uid('STORE', self.uid, '+FLAGS', flag)
-        if flag not in self.flags: self.flags.append(flag)
+        if flag not in self.flags:
+            self.flags.append(flag)
 
         trash = '[Gmail]/Trash' if '[Gmail]/Trash' in self.gmail.labels() else '[Gmail]/Bin'
         if self.mailbox.name not in ['[Gmail]/Bin', '[Gmail]/Trash']:
@@ -95,7 +103,6 @@ class Message():
     #     flag = '\\Deleted'
     #     self.gmail.imap.uid('STORE', self.uid, '-FLAGS', flag)
     #     if flag in self.flags: self.flags.remove(flag)
-
 
     def move_to(self, name):
         self.gmail.copy(self.uid, name, self.mailbox.name)
@@ -181,7 +188,6 @@ class Message():
                 if not isinstance(attachment, basestring) and attachment.get('Content-Disposition') is not None and attachment.get_filename() is not None
         ]
 
-
     def fetch(self):
         if not self.message:
             response, results = self.gmail.imap.uid('FETCH', self.uid, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
@@ -201,7 +207,8 @@ class Message():
         received_messages = {}
         uids = results[0].split(' ')
         if response == 'OK':
-            for uid in uids: received_messages[uid] = Message(original_mailbox, uid)
+            for uid in uids:
+                received_messages[uid] = Message(original_mailbox, uid)
             self.gmail.fetch_multiple_messages(received_messages)
             self.mailbox.messages.update(received_messages)
 
@@ -211,7 +218,8 @@ class Message():
         sent_messages = {}
         uids = results[0].split(' ')
         if response == 'OK':
-            for uid in uids: sent_messages[uid] = Message(self.gmail.mailboxes['[Gmail]/Sent Mail'], uid)
+            for uid in uids:
+                sent_messages[uid] = Message(self.gmail.mailboxes['[Gmail]/Sent Mail'], uid)
             self.gmail.fetch_multiple_messages(sent_messages)
             self.gmail.mailboxes['[Gmail]/Sent Mail'].messages.update(sent_messages)
 
@@ -228,7 +236,7 @@ class Attachment:
         # Raw file data
         self.payload = attachment.get_payload(decode=True)
         # Filesize in kilobytes
-        self.size = int(round(len(self.payload)/1000.0))
+        self.size = int(round(len(self.payload) / 1000.0))
 
     def save(self, path=None):
         if path is None:

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -178,7 +178,7 @@ class Message():
         # Parse attachments into attachment objects array for this message
         self.attachments = [
             Attachment(attachment) for attachment in self.message._payload
-                if not isinstance(attachment, basestring) and attachment.get('Content-Disposition') is not None
+                if not isinstance(attachment, basestring) and attachment.get('Content-Disposition') is not None and attachment.get_filename() is not None
         ]
 
 

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -230,13 +230,17 @@ class Message():
 
 
 class Attachment:
-
     def __init__(self, attachment):
         self.name = attachment.get_filename()
         # Raw file data
-        self.payload = attachment.get_payload(decode=True)
-        # Filesize in kilobytes
-        self.size = int(round(len(self.payload) / 1000.0))
+        if isinstance(attachment.get_payload(), basestring):
+            self.payload = attachment.get_payload(decode=True)
+            # Filesize in kilobytes
+            self.size = int(round(len(self.payload) / 1000.0))
+        else:
+            # Special case. Seems to occurs only for EML attachments.
+            self.payload = None
+            self.size = None
 
     def save(self, path=None):
         if path is None:

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -190,8 +190,10 @@ class Message():
                 elif content.get_content_type() == "text/html":
                     self.html = to_unicode(content.get_payload(decode=True), content.get_content_charset())
         elif self.message.get_content_maintype() == "text":
-            self.body = to_unicode(self.message.get_payload(decode=True), self.message.get_content_charset())
-
+            if self.message.get_content_type() == "text/plain":
+                self.body = to_unicode(self.message.get_payload(decode=True), self.message.get_content_charset())
+            elif self.message.get_content_type() == "text/html":
+                self.html = to_unicode(self.message.get_payload(decode=True), self.message.get_content_charset())
         try:
             self.sent_at = datetime.datetime.fromtimestamp(time.mktime(email.utils.parsedate_tz(self.message['date'])[:9]))
         except:

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -172,11 +172,6 @@ class Message():
 
         self.message = email.message_from_string(raw_email)
 
-        def to_unicode(value, charset):
-            r = try_parse(value, charset)
-
-            return r
-
         self.headers = self.parse_headers(self.message)
 
         self.to = self.parse_header(self.message['to'])
@@ -186,14 +181,14 @@ class Message():
         if self.message.get_content_maintype() == "multipart":
             for content in self.message.walk():
                 if content.get_content_type() == "text/plain":
-                    self.body = to_unicode(content.get_payload(decode=True), content.get_content_charset())
+                    self.body = try_parse(content.get_payload(decode=True), content.get_content_charset())
                 elif content.get_content_type() == "text/html":
-                    self.html = to_unicode(content.get_payload(decode=True), content.get_content_charset())
+                    self.html = try_parse(content.get_payload(decode=True), content.get_content_charset())
         elif self.message.get_content_maintype() == "text":
             if self.message.get_content_type() == "text/plain":
-                self.body = to_unicode(self.message.get_payload(decode=True), self.message.get_content_charset())
+                self.body = try_parse(self.message.get_payload(decode=True), self.message.get_content_charset())
             elif self.message.get_content_type() == "text/html":
-                self.html = to_unicode(self.message.get_payload(decode=True), self.message.get_content_charset())
+                self.html = try_parse(self.message.get_payload(decode=True), self.message.get_content_charset())
         try:
             self.sent_at = datetime.datetime.fromtimestamp(time.mktime(email.utils.parsedate_tz(self.message['date'])[:9]))
         except:

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -240,8 +240,11 @@ class Message():
 
 class Attachment:
     def __init__(self, attachment):
-        dh = decode_header(attachment.get_filename())
-        self.name = ''.join([try_parse(t[0], t[1]) for t in dh])
+        try:
+            dh = decode_header(attachment.get_filename())
+            self.name = ''.join([try_parse(t[0], t[1]) for t in dh])
+        except UnicodeEncodeError:
+            self.name = attachment.get_filename()
 
         # Raw file data
         if isinstance(attachment.get_payload(), basestring):

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -177,7 +177,10 @@ class Message():
         elif self.message.get_content_maintype() == "text":
             self.body = to_unicode(self.message.get_payload(decode=True), self.message.get_content_charset())
 
-        self.sent_at = datetime.datetime.fromtimestamp(time.mktime(email.utils.parsedate_tz(self.message['date'])[:9]))
+        try:
+            self.sent_at = datetime.datetime.fromtimestamp(time.mktime(email.utils.parsedate_tz(self.message['date'])[:9]))
+        except:
+            self.sent_at = datetime.datetime.now()
 
         self.flags = self.parse_flags(raw_headers)
 

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -135,7 +135,7 @@ class Message():
 
         try:
             return unicode(header, encoding)
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, LookupError):
             try:
                 return unicode(header, 'ISO-8859-1')
             except UnicodeDecodeError:

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -150,7 +150,9 @@ class Message():
                     if content.get_content_charset():
                         self.html = unicode(self.html, content.get_content_charset(), 'ignore').encode('utf8', 'replace')
         elif self.message.get_content_maintype() == "text":
-            self.body = self.message.get_payload()
+            self.body = self.message.get_payload(decode=True)
+            if self.message.get_content_charset():
+                self.body = unicode(self.body, self.message.get_content_charset(), 'ignore').encode('utf8', 'replace')
 
         self.sent_at = datetime.datetime.fromtimestamp(time.mktime(email.utils.parsedate_tz(self.message['date'])[:9]))
 

--- a/gmail/utf.py
+++ b/gmail/utf.py
@@ -10,10 +10,10 @@
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -26,6 +26,7 @@ text_type = unicode
 binary_type = str
 
 PRINTABLE = set(range(0x20, 0x26)) | set(range(0x27, 0x7f))
+
 
 def encode(s):
     """Encode a folder name using IMAP modified UTF-7 encoding.
@@ -56,6 +57,7 @@ def encode(s):
     extend_result_if_chars_buffered()
 
     return ''.join(r)
+
 
 def decode(s):
     """Decode a folder name from IMAP modified UTF-7 encoding to unicode.
@@ -88,10 +90,12 @@ def decode(s):
 
     return ''.join(r)
 
+
 def modified_utf7(s):
     # encode to utf-7: '\xff' => b'+AP8-', decode from latin-1 => '+AP8-'
     s_utf7 = s.encode('utf-7').decode('latin-1')
     return s_utf7[1:-1].replace('/', ',')
+
 
 def modified_deutf7(s):
     s_utf7 = '+' + s.replace(',', '/') + '-'

--- a/gmail/utils.py
+++ b/gmail/utils.py
@@ -1,11 +1,11 @@
+from .gmail import Gmail
 
-
-from .gmail import Gmail 
 
 def login(username, password):
     gmail = Gmail()
     gmail.login(username, password)
     return gmail
+
 
 def authenticate(username, access_token):
     gmail = Gmail()


### PR DESCRIPTION
This is a "small" yet useful PR, with several features:
- Allow for complex, custom IMAP queries using new `custom_query` parameter
- Store mailbox attributes. This is better for i18n, since "All Mail" only exists on english GMail (and the only way to retrieve the "all mail" name is to look for "\All" in the attributes)
- Parse `from` and `to` headers (quoted printable content)
- Encode `body` and `text` from mail_encoding to unicode

Sorry, should have broken this into several smaller PR.
