### PR TITLE
fix a bug when content of attachment is None (strange bug with email for...

### DIFF
--- a/gmail/message.py
+++ b/gmail/message.py
@@ -131,7 +131,11 @@ class Message():
     def parse_subject(self, encoded_subject):
         dh = decode_header(encoded_subject)
         default_charset = 'ASCII'
-        return ''.join([ unicode(t[0], t[1] or default_charset) for t in dh ])
+        try:
+            parsed_subject = ''.join([ unicode(t[0], t[1] or default_charset) for t in dh ])
+        except UnicodeDecodeError:
+            parsed_subject = ''
+        return parsed_subject
 
     def parse(self, raw_message):
         raw_headers = raw_message[0]

--- a/gmail/message.py
+++ b/gmail/message.py
@@ -220,7 +220,10 @@ class Attachment:
         # Raw file data
         self.payload = attachment.get_payload(decode=True)
         # Filesize in kilobytes
-        self.size = int(round(len(self.payload)/1000.0))
+        try:
+            self.size = int(round(len(self.payload) / 1000.0))
+        except TypeError:
+            self.size = 0
 
     def save(self, path=None):
         if path is None:


### PR DESCRIPTION
fix a bug when content of attachment is None (strange bug with email forward)

I should fix the problem by allowing attachments like this one but I ddon't have time right now 

--_004_AED2489C945A0F43BAB44072BC97FA211A64EFECTOREXCHANGE01co_
Content-Type: message/rfc822
Content-Disposition: attachment;
    creation-date="Thu, 20 Mar 2014 19:26:43 GMT";
    modification-date="Thu, 20 Mar 2014 19:26:43 GMT"
....
