### PR TITLE
Add hook to avoid parsing attachments

### DIFF
--- a/gmail/exceptions.py
+++ b/gmail/exceptions.py
@@ -21,3 +21,6 @@ class AuthenticationError(GmailException):
 
 class Timeout(GmailException):
     """The request timed out."""
+
+class AttachmentException(GmailException):
+    """Something went wrong with an attachment"""

--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -146,14 +146,14 @@ class Gmail():
             self.use_mailbox(from_mailbox)
         self.imap.uid('COPY', uid, to_mailbox)
 
-    def fetch_multiple_messages(self, messages):
+    def fetch_multiple_messages(self, messages, skip_attachments=False):
         fetch_str =  ','.join(messages.keys())
         response, results = self.imap.uid('FETCH', fetch_str, '(BODY.PEEK[] FLAGS X-GM-THRID X-GM-MSGID X-GM-LABELS)')
         for index in xrange(len(results) - 1):
             raw_message = results[index]
             if re.search(r'UID (\d+)', raw_message[0]):
                 uid = re.search(r'UID (\d+)', raw_message[0]).groups(1)[0]
-                messages[uid].parse(raw_message)
+                messages[uid].parse(raw_message, skip_attachments)
 
         return messages
 

--- a/gmail/mailbox.py
+++ b/gmail/mailbox.py
@@ -56,6 +56,8 @@ class Mailbox():
 
         kwargs.get('query') and search.extend([kwargs.get('query')])
 
+        skip_attachments = kwargs.get('skip_attachments', False)
+
         emails = []
         # print search
         response, data = self.gmail.imap.uid('SEARCH', *search)
@@ -71,7 +73,7 @@ class Mailbox():
                 messages_dict = {}
                 for email in emails:
                     messages_dict[email.uid] = email
-                self.messages.update(self.gmail.fetch_multiple_messages(messages_dict))
+                self.messages.update(self.gmail.fetch_multiple_messages(messages_dict, skip_attachments))
 
         return emails
 


### PR DESCRIPTION
This pull request includes a new exception type to raise when attachment parsing does not work and a hook to ignore attachment parsing entirely as a work-around. There's a little bit of PEP8 cleanup as well. Not sure anyone else will actually need this but I figured I'd make it available as a result of running into an exception like the following:

```
  File "/path/venv/lib/python2.7/site-packages/gmail/mailbox.py", line 74, in mail
    self.messages.update(self.gmail.fetch_multiple_messages(messages_dict))
  File "/path/venv/lib/python2.7/site-packages/gmail/gmail.py", line 156, in fetch_multiple_messages
    messages[uid].parse(raw_message)
  File "/path/venv/lib/python2.7/site-packages/gmail/message.py", line 173, in parse
    if not isinstance(attachment, basestring) and attachment.get('Content-Disposition') is not None
  File "/path/venv/lib/python2.7/site-packages/gmail/message.py", line 223, in __init__
    self.size = int(round(len(self.payload)/1000.0))
TypeError: object of type 'NoneType' has no len()
```