### PR TITLE
Force connection over `imap.gmail.com`s IPv4 address

### DIFF
--- a/gmail/gmail.py
+++ b/gmail/gmail.py
@@ -1,6 +1,8 @@
 import re
 import imaplib
 
+from socket import socket
+
 from mailbox import Mailbox
 from utf import encode as encode_utf7, decode as decode_utf7
 from exceptions import *
@@ -38,7 +40,15 @@ class Gmail():
         #         raise Exception('Connection failure.')
         #     self.imap = None
 
-        self.imap = imaplib.IMAP4_SSL(self.GMAIL_IMAP_HOST, self.GMAIL_IMAP_PORT)
+        # Gmail doesn't allow us to connect to it via IPv6, so the below resolves `imap.gmail.com`
+        # to its IPv4 address and connects using that.
+        # See https://blog.zensoftware.co.uk/2016/05/13/gmail-blocking-mdaemon-email-arriving-via-ipv6/
+        ipv4_gmail_connection = socket()
+        ipv4_gmail_connection.connect((self.GMAIL_IMAP_HOST, self.GMAIL_IMAP_PORT))
+
+        gmail_imap_ipv4_address = ipv4_gmail_connection.getpeername()[0]
+
+        self.imap = imaplib.IMAP4_SSL(gmail_imap_ipv4_address, self.GMAIL_IMAP_PORT)
 
         # self.smtp = smtplib.SMTP(self.server,self.port)
         # self.smtp.set_debuglevel(self.debug)


### PR DESCRIPTION
This should allow us to login to gmail on machines that use IPv6, by forcing the use of IPv4

See https://blog.zensoftware.co.uk/2016/05/13/gmail-blocking-mdaemon-email-arriving-via-ipv6/